### PR TITLE
Fix IE11 alignment bug on Image Text block

### DIFF
--- a/assets/scss/blocks/_b-image-text.scss
+++ b/assets/scss/blocks/_b-image-text.scss
@@ -46,14 +46,7 @@ $textMargin : true; // textarea top/bottom margin
         @include bp(sm) {
             max-width: $container-max-width/2;
             width: $container-width/2;
-            margin: initial;
-
-            .b-image-text--left & {
-                margin-right: 0px;
-            }
-            .b-image-text--right & {
-                margin-left: 0px;
-            }
+            margin: 0;
         }
     }
 

--- a/assets/scss/blocks/_b-image-text.scss
+++ b/assets/scss/blocks/_b-image-text.scss
@@ -47,6 +47,13 @@ $textMargin : true; // textarea top/bottom margin
             max-width: $container-max-width/2;
             width: $container-width/2;
             margin: initial;
+
+            .b-image-text--left & {
+                margin-right: 0px;
+            }
+            .b-image-text--right & {
+                margin-left: 0px;
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses a bug reported (wrongly) in our private Image Text -block repository over at Bitbucket (https://bitbucket.org/evermade/image-text-block/issues/1/ie11-text-container-overflows).

## Description
Prior to this PR, the Image Text -block text content overflows the page container. This PR addresses this issue, so that the text content is aligned correctly to the edges of the container.

Please see the (again, wrongly) flagged issue over at the Bitbucket repo.

## Related Issue
As noted above, I've (wrongly) created an issue against the Image Text block repo over at Bitbucket, but for the sake of common sense I'm not re-creating it here again just to have it closed down right after. Sorry!

## Motivation and Context
Block didn't work with IE11 correctly. With this PR it does.

## How Has This Been Tested?
I've tested this with our generally supported browsers and it seems to work in all of them (IE11, Edge, Chrome, Firefox, Safari, Mobile Safari, Mobile Chrome, Mobile Firefox).