### PR TITLE
Fix custom post type slug bug

### DIFF
--- a/lib/post-types.php
+++ b/lib/post-types.php
@@ -7,6 +7,7 @@ namespace Evermade\Swiss\PostTypes;
  * -----------------------------------------------------
  */
 
+/*
 function exampleSetup()
 {
     $labels = array(
@@ -37,12 +38,13 @@ function exampleSetup()
         'exclude_from_search'   => true,
         'menu_icon'             => 'dashicons-book',
         'rewrite'               => array(
-            'slug' => _x('example', 'URL slug', 'swiss')
+            'slug' => 'example'
         )
     );
 
     register_post_type('example', $args);
 }
+*/
 
 /*
  * -----------------------------------------------------


### PR DESCRIPTION
This PR disables string translation of the custom post type slugs. Currently, if custom post type's slug is translated via WPML's String Translation tool (with the help of `_x()` or `__()`), custom posts cannot be visited in the frontend.

The correct way to translate custom post types' slugs is setting them in WPML → Settings. The slug in the CPT declaration is meant to be used only as a key. Nothing currently breaks though if the slug's string itself is left not translated.

## How Has This Been Tested?
The bug was originally fixed for the RuokaTutka project, live at http://ruokatutka.em87.io/ .