### PR TITLE
Apply scheme text colors to all elements

### DIFF
--- a/assets/scss/base/_base.scss
+++ b/assets/scss/base/_base.scss
@@ -38,6 +38,7 @@ body {
     @include font-size(base);
 
     background-color: $color-body;
+    color: $color-text;
     font-family: $font-family-default;
     font-weight: $font-weight-default;
     line-height: $line-height-base;

--- a/assets/scss/mixins/_scheme-html.scss
+++ b/assets/scss/mixins/_scheme-html.scss
@@ -13,7 +13,9 @@ Don't use the @scheme-html(); because then you will have no way to later on reus
 
 @mixin scheme-html($s-text-color: $color-text, $s-headings-color: $color-heading, $s-link-color: $color-link) {
 
-    p a:not(.c-btn) {
+    color: $s-text-color;
+
+    a:not(.c-btn) {
         color: $s-link-color;
     }
 
@@ -28,13 +30,6 @@ Don't use the @scheme-html(); because then you will have no way to later on reus
         a:not(.c-btn) {
             color: $s-headings-color;
         }
-    }
-
-    ul,
-    li,
-    p,
-    span {
-        color: $s-text-color;
     }
 
     /*


### PR DESCRIPTION
This PR removes element level selectors from scheme-html mixin and sets scheme colors generally.

This PR also sets missing global color, which is a pure bug.

Now the text colors are only applied on p, ul, li and span elements, so elements not included here will not inherit the right coloring. Usage of element level selectors also increases the specifity for no reason.

This PR should fix #33.

## How Has This Been Tested?
This is a combination of scheme-html files of [RuokaTutka](https://bitbucket.org/evermade/ruokatutka/src/master/app/src/wp-content/themes/swiss/assets/scss/mixins/_scheme-html.scss) and [WulffEntre](https://bitbucket.org/evermade/wulffentre-wp/src/master/app/src/wp-content/themes/swiss/assets/scss/mixins/_scheme-html.scss) projects.