### PR TITLE
Add lang to <html> by default

### DIFF
--- a/templates/head.php
+++ b/templates/head.php
@@ -14,7 +14,7 @@
 
 -->
 <!doctype html>
-<html class="no-js" lang="">
+<html class="no-js" <?php language_attributes(); ?>>
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
This PR hands the `<html>`'s `lang` attribute setting over to the WordPress's native function `language_attributes()`. This way the lang tags are ready out-of-box and compatible with WPML as well.

The `language_attributes()` uses the site language that can be set on admin panel's General Settings.