### PR TITLE
Bug: bust some cache on editor plugin js

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -47,7 +47,7 @@ function customMCEbuttons()
 // load our js
 function custom_tinymce_plugin($plugin_array)
 {
-    $plugin_array['custom_mce_em_buttons'] = get_template_directory_uri() .'/assets/admin/js/editor_plugin.js';
+    $plugin_array['custom_mce_em_buttons'] = get_template_directory_uri() .'/assets/admin/js/editor_plugin.' . filemtime(get_template_directory() . '/assets/admin/js/editor_plugin.js') . '.js';
     return $plugin_array;
 }
 


### PR DESCRIPTION
Currently there's no cache busting on our WYSIWYG editors' plugin JavaScript. Our current server configurations produces pretty aggressive caching of static assets, which is good, but also forces us to bust the browser cache in some way.

This PR is made in the same way as in the frontend CSS and JS, so everything works on our server configurations out-of-the-box.

## How Has This Been Tested?
Tested on [RuokaTutka](http://ruokatutka.em87.io/).