### PR TITLE
Add type declarations for theme functions

### DIFF
--- a/lib/functions/acf.php
+++ b/lib/functions/acf.php
@@ -7,7 +7,7 @@
  * @param  string $name [description]
  * @return [type]       [description]
  */
-function postBlocks($name='page', $version='v1')
+function postBlocks(string $name='page', string $version='v1') : bool
 {
 
     //lets check is ACF available
@@ -34,9 +34,9 @@ function postBlocks($name='page', $version='v1')
  *
  * @param string $size
  * @param [type] $key
- * @return void
+ * @return string|null
  */
-function getImageUrl($size='original', $data=null)
+function getImageUrl(string $size='original', $data=null) : ?string
 {
 
     // bail out if we dont have what we need
@@ -67,9 +67,9 @@ function getImageUrl($size='original', $data=null)
  * @param string $size
  * @param [type] $key
  * @param string $class
- * @return void
+ * @return string|null
  */
-function getImage($size='medium-large', $key=null, $class='')
+function getImage(string $size='medium-large', $key=null, string $class='') : ?string
 {
     $imageUrl = \Evermade\Swiss\Acf\getImageUrl($size, $key);
 
@@ -95,7 +95,7 @@ function getOption($group_fields)
     return $group_data;
 }
 
-function isAcfActive()
+function isAcfActive() : bool
 {
     return (function_exists('has_sub_field'))? true : false;
 }
@@ -103,9 +103,9 @@ function isAcfActive()
 /**
  * Register our local block field groups via PHP to help distribute and share blocks amognst projects
  *
- * @return void
+ * @return bool
  */
-function registerLocalBlockFieldGroups()
+function registerLocalBlockFieldGroups() : bool
 {
 
     // if we have ACF enabled
@@ -175,7 +175,7 @@ function registerLocalBlockFieldGroups()
     return false;
 }
 
-function defaultBlocks($value, $post_id, $field)
+function defaultBlocks($value, int $post_id, $field)
 {
     global $post;
 

--- a/lib/functions/blog.php
+++ b/lib/functions/blog.php
@@ -6,7 +6,7 @@
  * @param  array  $array [description]
  * @return [type]        [description]
  */
-function getPostsReadMore($postAmount, $postExcluded = "")
+function getPostsReadMore(int $postAmount, $postExcluded = "") : array
 {
     $args = array(
         'posts_per_page'  => $postAmount,

--- a/lib/functions/index.php
+++ b/lib/functions/index.php
@@ -6,7 +6,7 @@
  * @param  array  $array [description]
  * @return [type]        [description]
  */
-function getFrom($key=null, $array=array(), $default=null)
+function getFrom($key=null, array $array=array(), $default=null)
 {
 
     // if we have an object
@@ -28,7 +28,7 @@ function getFrom($key=null, $array=array(), $default=null)
  * @param  [type] &$data [data pass in by reference to template]
  * @return [type]        [html]
  */
-function template($name = null, $data=null, $dir='templates')
+function template(?string $name = null, $data=null, string $dir='templates') : ?string
 {
     if (!file_exists((get_template_directory().'/'.$dir.'/'.$name))) {
         return null;
@@ -42,7 +42,7 @@ function template($name = null, $data=null, $dir='templates')
     return $html;
 }
 
-function getImageSizes($size = '')
+function getImageSizes(string $size = '')
 {
     global $_wp_additional_image_sizes;
 
@@ -57,10 +57,10 @@ function getImageSizes($size = '')
             $sizes[ $_size ]['crop'] = (bool) get_option($_size . '_crop');
         } elseif (isset($_wp_additional_image_sizes[ $_size ])) {
             $sizes[ $_size ] = array(
-                                'width' => $_wp_additional_image_sizes[ $_size ]['width'],
-                                'height' => $_wp_additional_image_sizes[ $_size ]['height'],
-                                'crop' =>  $_wp_additional_image_sizes[ $_size ]['crop']
-                        );
+                'width' => $_wp_additional_image_sizes[ $_size ]['width'],
+                'height' => $_wp_additional_image_sizes[ $_size ]['height'],
+                'crop' => $_wp_additional_image_sizes[ $_size ]['crop']
+            );
         }
     }
 
@@ -76,7 +76,7 @@ function getImageSizes($size = '')
     return $sizes;
 }
 
-function defaultImg($size='thumbnail', $text='img')
+function defaultImg(string $size='thumbnail', string $text='img') : string
 {
     $sizes = \Evermade\Swiss\getImageSizes();
 
@@ -87,7 +87,7 @@ function defaultImg($size='thumbnail', $text='img')
     return sprintf('https://fakeimg.pl/%sx%s/666/fff/?text=%s', 850, 850, $text);
 }
 
-function featuredImageUrl($size='medium-large', $post=null)
+function featuredImageUrl(string $size='medium-large', ?object $post=null) : ?string
 {
 
     //if we have no post then lets bring in the global post
@@ -109,12 +109,12 @@ function featuredImageUrl($size='medium-large', $post=null)
     return $img;
 }
 
-function isDev()
+function isDev() : bool
 {
     return (getenv('APP_ENV') == 'production')? false : true;
 }
 
-function debug($msg=null, $style='php')
+function debug($msg=null, string $style='php') : bool
 {
     if (\Evermade\Swiss\isDev()) {
         if ($style == 'php') {
@@ -135,10 +135,10 @@ function debug($msg=null, $style='php')
 /**
  * a generic sprintf for handling both arrays and single strings for quick if templating
  * @param  string $str   [description]
- * @param  [type] $input [description]
- * @return [type]        [description]
+ * @param  string|array $input [description]
+ * @return string|null        [description]
  */
-function sprint($str='', $input)
+function sprint(string $str='', $input) : ?string
 {
 
     //if an array
@@ -168,17 +168,21 @@ function sprint($str='', $input)
 
 /**
  * [excerpt description]
- * @param  [type]  $str   [description]
- * @param  integer $limit [description]
- * @return [type]         [description]
+ * @param  string  $str [description]
+ * @param  int $limit   [description]
+ * @return string       [description]
  */
-function excerpt($str, $limit = 255)
+function excerpt(string $str, int $limit = 255) : string
 {
     $strlen = strlen($str);
     return ($strlen>=$limit) ? substr($str, 0, $limit)."&hellip;" : $str;
 }
 
-function sharePage()
+/**
+ * [sharePage description]
+ * @return string  [description]
+ */
+function sharePage() : ?string
 {
     $html = null;
     $template = get_template_directory().'/templates/_share-page.php';
@@ -225,9 +229,9 @@ function sharePage()
  * @param  string $type  [description]
  * @param  string $url   [description]
  * @param  string $title [description]
- * @return string        [description]
+ * @return string|null   [description]
  */
-function shareLink($type='facebook', $url=null, $title='')
+function shareLink(string $type='facebook', ?string $url=null, string $title='') : ?string
 {
     $data = array();
     $urls = array(
@@ -267,7 +271,7 @@ function shareLink($type='facebook', $url=null, $title='')
  * Returns the fully qualified URL for a request.
  * @return string The request URL, including the protocol and query parameters.
  */
-function currentPageUrl()
+function currentPageUrl() : string
 {
     $pageURL = 'http';
     if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {


### PR DESCRIPTION
## Description
This PR adds type declarations for theme functions, and updates some of the documented types to match what the functions actually return.

Note that not all values for all functions are handled, as [PHP doesn't currently support](https://wiki.php.net/rfc/union_types) union types that would allow us to be more specific about the mixed types. In these cases, type declarations have simply been omitted.

## Motivation and Context
Main motivation is about making it easier to reason about what function inputs and outputs are. Additionally, documentation generation and unit testing tools (which we want to introduce at some point in the future) can use the type hints to be more specific about what types functions should work with.

This also helps us establish an example of how we could (and should) be doing PHP function type declarations in the future, so that Swiss can serve as a better example for new developers joining the company.

If desired, PHP can also be instructed to follow the type declarations strictly (rather than just coercing values), assuming we want to be more strict about the used types at some point.

Lastly, future versions of PHP can get better performance with functions that have function types declared. This way we're future-proofing our work for better performance (assuming WP is still around when these future improvements land).

This has been a pending work that has awaited for us to fully embrace PHP 7, as not too long ago our staging server was still stuck with PHP 5. Now that this has changed, all our environments from development to staging to production use PHP 7.2.

## How Has This Been Tested?
Set up a fresh Dockerpress site using my fork of Swiss. Ran through all features,  and saw no regressions.