### PR TITLE
page blocks editing view shows block title in the box handle

### DIFF
--- a/assets/admin/css/acf.css
+++ b/assets/admin/css/acf.css
@@ -1,0 +1,7 @@
+.layout .acf-fc-layout-handle[data-block-title]::after {
+    content: attr(data-block-title);
+    display: inline;
+    font-size: 85%;
+    opacity: 0.6;
+    margin: 0 0 0 1em;
+}

--- a/assets/admin/css/acf.css
+++ b/assets/admin/css/acf.css
@@ -1,7 +1,12 @@
 .layout .acf-fc-layout-handle[data-block-title]::after {
     content: attr(data-block-title);
-    display: inline;
+    display: inline-block;
+    vertical-align: middle;
     font-size: 85%;
     opacity: 0.6;
     margin: 0 0 0 1em;
+    max-width: 50%;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }

--- a/assets/admin/js/acf.js
+++ b/assets/admin/js/acf.js
@@ -2,28 +2,66 @@
 
     jQuery(function() {
 
-        function collapseAll(el) {
-
+        function collapse( el ) {
             el.addClass("-collapsed");
-            var schemeFound = el.find('div.acf-field-5846bc36abec7').eq(0);
+        }
 
-            if(schemeFound.length == 1) {
+        function styleSectionBlocks( el ) {
+            if ( el.data('layout') == 'section' ) {
 
                 el.css({'background': '#eee'});
 
-                if(found > 1) {
+                if ( found > 1 ) {
                     el.css({'margin-top': '40px'});
                 }
 
                 found++;
+
             }
+        }
+
+        function appendBlockTitles( el ) {
+
+            // sniff the block title from the acf markup
+
+            var $handle = el.find('.acf-fc-layout-handle');
+            $handle.find('.js-block-title').remove();
+
+            var blockTitle = '';
+
+            var titleInput = el.find('input[name*="_title"],input[name*="_heading"]');
+            blockTitle = titleInput.length ? titleInput.val() : '';
+
+            if ( blockTitle == '' ) {
+                // no title-field, try to find first header in a columns textarea
+                var textarea = el.find('textarea[name*="_columns"]');
+                if ( textarea.length ) {
+                    blockTitle = jQuery( '<div>'+textarea.val()+'</div>' ).find('h1,h2,h3').text();
+                }
+            }
+
+            if ( blockTitle != '' ) {
+                var style = 'font-size: 85%; opacity: 0.6; margin-left: 1em;';
+                $handle.append('<span class="js-block-title" style="'+style+'">'+blockTitle+'</span>');
+            }
+
         }
 
         var found = 0;
 
         jQuery('.layout').each(function(index) {
-            collapseAll(jQuery(this));
+            var $block = $(this);
+            collapse( $block );
+            styleSectionBlocks( $block );
+            appendBlockTitles( $block );
         });
+
+        // refresh block titles every 15 s
+        setInterval(function(){
+            jQuery('.layout').each(function(index) {
+                appendBlockTitles( $(this) );
+            });
+        },1000*15);
     });
 
 })();

--- a/assets/admin/js/acf.js
+++ b/assets/admin/js/acf.js
@@ -20,7 +20,7 @@
             }
         }
 
-        function appendBlockTitles( el ) {
+        function appendBlockTitle( el ) {
 
             // sniff the block title from the acf markup
 
@@ -34,34 +34,35 @@
 
             if ( blockTitle == '' ) {
                 // no title-field, try to find first header in a columns textarea
-                var textarea = el.find('textarea[name*="_columns"]');
+                var textarea = el.find('textarea[name*="_columns"],textarea[name*="_hero"],textarea[name*="_section-header"],textarea[name*="_slide-list"]');
                 if ( textarea.length ) {
                     blockTitle = jQuery( '<div>'+textarea.val()+'</div>' ).find('h1,h2,h3').text();
                 }
             }
 
             if ( blockTitle != '' ) {
-                var style = 'font-size: 85%; opacity: 0.6; margin-left: 1em;';
-                $handle.append('<span class="js-block-title" style="'+style+'">'+blockTitle+'</span>');
+                // just add data attribute, css will handle the rest
+                $handle[0].setAttribute('data-block-title', blockTitle);
             }
 
         }
 
-        var found = 0;
-
-        jQuery('.layout').each(function(index) {
-            var $block = $(this);
-            collapse( $block );
-            styleSectionBlocks( $block );
-            appendBlockTitles( $block );
-        });
-
-        // refresh block titles every 15 s
-        setInterval(function(){
+        function runAll() {
             jQuery('.layout').each(function(index) {
-                appendBlockTitles( $(this) );
+
+                var $block = $(this);
+                collapse( $block );
+                styleSectionBlocks( $block );
+                appendBlockTitle( $block );
+
             });
-        },1000*15);
+        }
+
+
+        // initial run
+        var found = 0;
+        runAll();
+
     });
 
 })();

--- a/assets/admin/js/acf.js
+++ b/assets/admin/js/acf.js
@@ -1,68 +1,75 @@
 (function() {
-
     jQuery(function() {
-
-        function collapse( el ) {
-            el.addClass("-collapsed");
+        function collapse(el) {
+            el.classList.add("-collapsed");
         }
 
-        function styleSectionBlocks( el ) {
-            if ( el.data('layout') == 'section' ) {
-
-                el.css({'background': '#eee'});
-
-                if ( found > 1 ) {
-                    el.css({'margin-top': '40px'});
+        function styleSectionBlocks(el, first) {
+            if (el.getAttribute("data-layout") == "section") {
+                el.style.backgroundColor = "#eee";
+                if (!first) {
+                    el.style.marginTop = "40px";
                 }
-
-                found++;
-
             }
         }
 
-        function appendBlockTitle( el ) {
+        function readTextInputs(el) {
+            // define selectors to search
+            var selectors = [
+                'input[name*="_title"]',
+                'input[name*="_heading"]'
+            ];
+            var textInput = el.querySelector(selectors.join(","));
 
+            return textInput ? textInput.value : "";
+        }
+
+        function readTextareas(el) {
+            // define selectors to search
+            var selectors = [
+                'textarea[name*="_columns"]',
+                'textarea[name*="_hero"]',
+                'textarea[name*="_section-header"]',
+                'textarea[name*="_slide-list"]'
+            ];
+            var textarea = el.querySelector(selectors.join(","));
+
+            return textarea
+                ? jQuery("<div>" + textarea.value + "</div>")
+                      .find("h1,h2,h3")
+                      .text()
+                : "";
+        }
+
+        function appendBlockTitle(el) {
             // sniff the block title from the acf markup
 
-            var $handle = el.find('.acf-fc-layout-handle');
-            $handle.find('.js-block-title').remove();
+            // the handle is where we'll inject the title
+            var handle = el.querySelector(".acf-fc-layout-handle");
 
-            var blockTitle = '';
+            if (!handle) return false;
 
-            var titleInput = el.find('input[name*="_title"],input[name*="_heading"]');
-            blockTitle = titleInput.length ? titleInput.val() : '';
+            // look for a title in some text -inputs first
+            var blockTitle = readTextInputs(el);
 
-            if ( blockTitle == '' ) {
-                // no title-field, try to find first header in a columns textarea
-                var textarea = el.find('textarea[name*="_columns"],textarea[name*="_hero"],textarea[name*="_section-header"],textarea[name*="_slide-list"]');
-                if ( textarea.length ) {
-                    blockTitle = jQuery( '<div>'+textarea.val()+'</div>' ).find('h1,h2,h3').text();
-                }
-            }
+            // if a title wasn't found in any text inputs, try wysiwyg editors
+            blockTitle = blockTitle ? blockTitle : readTextareas(el);
 
-            if ( blockTitle != '' ) {
-                // just add data attribute, css will handle the rest
-                $handle[0].setAttribute('data-block-title', blockTitle);
-            }
-
+            // inject the block title in the acf markup if found
+            handle.setAttribute("data-block-title", blockTitle);
         }
 
         function runAll() {
-            jQuery('.layout').each(function(index) {
+            var blocks = document.querySelectorAll(".layout");
 
-                var $block = $(this);
-                collapse( $block );
-                styleSectionBlocks( $block );
-                appendBlockTitle( $block );
-
-            });
+            for (var i = 0; i < blocks.length; i++) {
+                collapse(blocks[i]);
+                styleSectionBlocks(blocks[i], i == 0);
+                appendBlockTitle(blocks[i]);
+            }
         }
 
-
         // initial run
-        var found = 0;
         runAll();
-
     });
-
 })();

--- a/lib/assets.php
+++ b/lib/assets.php
@@ -28,6 +28,7 @@ add_action('wp_enqueue_scripts', 'Evermade\Swiss\Assets\publicScriptsAndStyles')
 function admin_scripts_and_styles()
 {
     wp_enqueue_script('swiss-acf', get_template_directory_uri().'/assets/admin/js/acf.'.filemtime(get_stylesheet_directory() . '/assets/admin/js/acf.js').'.js', array(), null, true);
+    wp_enqueue_style('swiss-acf', get_template_directory_uri().'/assets/admin/css/acf.'.filemtime(get_stylesheet_directory() . '/assets/admin/css/acf.css').'.css');
 }
 
 add_action('admin_enqueue_scripts', 'Evermade\Swiss\Assets\admin_scripts_and_styles');


### PR DESCRIPTION
## Description
Have you created a long page with Everblox? Did you lose that Columns-block you were still editing because there are 15 other columns blocks on the page?? Are you completely lost?!?!? Don't worry, with "PAGE BLOCKS EDITING VIEW SHOWS BLOCK TITLE IN THE BOX HANDLE" you can now find your lost Columns block in just mere seconds!! This "PAGE BLOCKS EDITING VIEW SHOWS BLOCK TITLE IN THE BOX HANDLE" will show the title of each block in the top bar of the block and you will INSTANTLY find the block you were still working on!! ORDER (merge into master) NOW!

## Motivation and Context
Sebastian

## Screenshots (if appropriate):
![screen shot 2018-10-11 at 12 12 56](https://user-images.githubusercontent.com/14174760/46794504-9bd05680-cd50-11e8-83be-7990df8ff73b.png)
