### PR TITLE
Removed acf clones from section style selector. Fixes #43.

### DIFF
--- a/assets/admin/js/acf.js
+++ b/assets/admin/js/acf.js
@@ -60,7 +60,7 @@
         }
 
         function runAll() {
-            var blocks = document.querySelectorAll(".layout");
+            var blocks = document.querySelectorAll(".layout:not(.acf-clone)");
 
             for (var i = 0; i < blocks.length; i++) {
                 collapse(blocks[i]);


### PR DESCRIPTION
## Description
Avoid targeting the hidden `.acf-clone` fields in section selector.

## Related Issue
https://github.com/evermade/swiss/issues/43
